### PR TITLE
Rename bin symlink, 0.4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lamassu-coinapult",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Lamassu Coinapult Plugin",
   "main": "main.js",
   "scripts": {
@@ -21,7 +21,7 @@
     "url": "https://coinapult.com"
   },
   "bin": {
-    "setup": "./setup"
+    "coinapult-setup": "./setup"
   },
   "bugs": {
     "url": "https://github.com/coinapult/lamassu-coinapult/issues"


### PR DESCRIPTION
Changing so that each plugin can have a distinct setup script with `lamassu-server/node_modules/.bin`
